### PR TITLE
fix(sec): upgrade io.springfox:springfox-swagger-ui to 2.10.0

### DIFF
--- a/novel-admin/pom.xml
+++ b/novel-admin/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.java2nb</groupId>
@@ -168,7 +167,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.6.1</version>
+            <version>2.10.0</version>
         </dependency>
 
         <!-- 添加redis支持-->
@@ -272,8 +271,7 @@
                                         <include name="*.*"/>
                                     </fileset>
                                 </copy>
-                                <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar"
-                                      tofile="${project.build.directory}/build/${project.artifactId}.jar"/>
+                                <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar" tofile="${project.build.directory}/build/${project.artifactId}.jar"/>
 
                                 <fixcrlf srcdir="${basedir}/src/main/build/scripts" eol="unix"/>
                                 <copy todir="${project.build.directory}/build/bin">
@@ -283,8 +281,8 @@
                                         <include name="*.bat"/>
                                     </fileset>
                                 </copy>
-                                <zip destfile='${project.build.directory}/build/${project.artifactId}.zip'>
-                                    <zipfileset filemode="755" dir='${project.build.directory}/build/'/>
+                                <zip destfile="${project.build.directory}/build/${project.artifactId}.zip">
+                                    <zipfileset filemode="755" dir="${project.build.directory}/build/"/>
                                 </zip>
                             </tasks>
                         </configuration>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.springfox:springfox-swagger-ui 2.6.1
- [CVE-2019-17495](https://www.oscs1024.com/hd/CVE-2019-17495)


### What did I do？
Upgrade io.springfox:springfox-swagger-ui from 2.6.1 to 2.10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS