### PR TITLE
fix(sec): upgrade org.apache.shiro:shiro-spring to 1.9.1

### DIFF
--- a/novel-admin/pom.xml
+++ b/novel-admin/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-spring</artifactId>
-            <version>1.7.0</version>
+            <version>1.9.1</version>
         </dependency>
         <!-- shiro ehcache -->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.shiro:shiro-spring 1.7.0
- [CVE-2022-32532](https://www.oscs1024.com/hd/CVE-2022-32532)


### What did I do？
Upgrade org.apache.shiro:shiro-spring from 1.7.0 to 1.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS