### PR TITLE
fix(sec): upgrade org.apache.shiro:shiro-core to 1.9.1

### DIFF
--- a/novel-admin/pom.xml
+++ b/novel-admin/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-            <version>1.3.2</version>
+            <version>1.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.shiro</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.shiro:shiro-core 1.3.2
- [CVE-2021-41303](https://www.oscs1024.com/hd/CVE-2021-41303)


### What did I do？
Upgrade org.apache.shiro:shiro-core from 1.3.2 to 1.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS